### PR TITLE
Change macro annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 
 `wavegen` is a wavefrom generator made with 🦀
 
-Refer to [documentation](https://docs.rs/wavegen) for more exhaustive usage examples.
-
 ## How to use it?
 
 1) Define a waveform with sampling frequency and function components
@@ -23,6 +21,8 @@ let wf = Waveform::<f64>::with_components(200.0, vec![
 ```rust
 let some_samples: Vec<f64> = wf.iter().take(200).collect();
 ```
+
+Refer to [documentation](https://docs.rs/wavegen) for more exhaustive usage examples.
 
 ## Show me some examples!
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Refer to [documentation](https://docs.rs/wavegen) for more exhaustive usage exam
 1) Define a waveform with sampling frequency and function components
 
 ```rust
-let wf = Waveform::<f64>::with_components(200.0, vec![sine!(100, 10), dc_bias!(20)]);
+let wf = Waveform::<f64>::with_components(200.0, vec![
+        sine!(frequency: 100, amplitude: 10),
+        dc_bias!(20)
+    ]);
 ```
 
 2. Turn it into an iterator and sample

--- a/README.md
+++ b/README.md
@@ -67,3 +67,9 @@ wavegen = { version = "0.2", default-features = false, features = ["libm"] }
 
 ## Similar crates
 * [Waver](https://github.com/amrali/waver/) which was the inspiration for this crate
+
+## Breaking changes
+
+### 0.2
+
+0.2 intorduces a braking chnage in how macros are annotated, changing the annotation form from `frequency = n` to `frequency: n`

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -74,10 +74,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Sine 300Hz + 50 Hz",
         Waveform::<f32>::with_components(
             sample_rate,
-            vec![
-                sine!(frequency: 300),
-                sine!(frequency: 50, amplitude: 0.3)
-            ]
+            vec![sine!(frequency: 300), sine!(frequency: 50, amplitude: 0.3)]
         )
     )?;
 

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Sawtooth with sine",
         Waveform::<f32>::with_components(
             sample_rate,
-            vec![sawtooth!(2, 1, 0.0), sine!(frequency = 50, amplitude = 0.1)]
+            vec![sawtooth!(2, 1, 0.0), sine!(frequency: 50, amplitude: 0.1)]
         )
     )?;
 
@@ -75,8 +75,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Waveform::<f32>::with_components(
             sample_rate,
             vec![
-                sine!(frequency = 300),
-                sine!(frequency = 50, amplitude = 0.3)
+                sine!(frequency: 300),
+                sine!(frequency: 50, amplitude: 0.3)
             ]
         )
     )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,11 @@
 //! # Periodic function macros
 //! The macros for building predefined [PeriodicFunction]s generally have a form of:
 //!
-//! `function!(frequency, amplitude, phase)`
+//! `function!(frequency, [amplitude, [phase]])`
+//! 
+//! (Square braces "[]" indicate optional argument).
 //!
-//! They come in an annotated and non-annotated form, so for exmaple a Sine function can be expressed in both ways:
+//! They come in an annotated and non-annotated form, so for example a Sine function can be expressed in both ways:
 //! ```
 //! use wavegen::sine;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! The macros for building predefined [PeriodicFunction]s generally have a form of:
 //!
 //! `function!(frequency, [amplitude, [phase]])`
-//! 
+//!
 //! (Square braces "[]" indicate optional argument).
 //!
 //! They come in an annotated and non-annotated form, so for example a Sine function can be expressed in both ways:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! ```
 //! use wavegen::sine;
 //!
-//! let sine_f = sine!(frequency = 100, amplitude = 20, phase = 0.25);
+//! let sine_f = sine!(frequency: 100, amplitude: 20, phase: 0.25);
 //! ```
 //!
 //! Refer to Macros section for more info.

--- a/src/periodic_functions/sawtooth.rs
+++ b/src/periodic_functions/sawtooth.rs
@@ -35,16 +35,16 @@ macro_rules! sawtooth {
     ($frequency:expr) => {
         sawtooth!($frequency, 1.0, 0.0)
     };
-    (frequency = $frequency:expr) => {
+    (frequency: $frequency:expr) => {
         sawtooth!($frequency)
     };
     ($frequency:expr, $amplitude:expr) => {
         sawtooth!($frequency, $amplitude, 0.0)
     };
-    (frequency = $frequency:expr, amplitude = $amplitude:expr) => {
+    (frequency: $frequency:expr, amplitude: $amplitude:expr) => {
         sawtooth!($frequency, $amplitude)
     };
-    (frequency = $frequency:expr, amplitude = $amplitude:expr, phase = $phase:expr) => {
+    (frequency: $frequency:expr, amplitude: $amplitude:expr, phase: $phase:expr) => {
         sawtooth!($frequency, $amplitude, 0.0)
     };
     ($frequency:expr, $amplitude:expr, $phase:expr) => {

--- a/src/periodic_functions/sine.rs
+++ b/src/periodic_functions/sine.rs
@@ -43,7 +43,7 @@ pub fn _sine(frequency: f64, amplitude: f64, phase: f64) -> PeriodicFunction {
 /// ```
 /// use wavegen::sine;
 ///
-/// let sine = sine!(frequency = 50, amplitude = 20);
+/// let sine = sine!(frequency: 50, amplitude: 20);
 /// ```
 ///
 /// 50 Hz sine of amplitude 20 and phase shift of half a turn
@@ -55,13 +55,13 @@ pub fn _sine(frequency: f64, amplitude: f64, phase: f64) -> PeriodicFunction {
 /// ```
 #[macro_export]
 macro_rules! sine {
-    (frequency = $frequency:expr) => {
+    (frequency: $frequency:expr) => {
         sine!($frequency)
     };
-    (frequency = $frequency:expr, amplitude = $amplitude:expr) => {
+    (frequency: $frequency:expr, amplitude: $amplitude:expr) => {
         sine!($frequency, $amplitude)
     };
-    (frequency = $frequency:expr, amplitude = $amplitude:expr, phase = $phase:expr) => {
+    (frequency: $frequency:expr, amplitude: $amplitude:expr, phase: $phase:expr) => {
         sine!($frequency, $amplitude, $phase)
     };
     ($frequency:expr) => {

--- a/src/periodic_functions/square.rs
+++ b/src/periodic_functions/square.rs
@@ -30,13 +30,13 @@ pub fn _square(frequency: f64, amplitude: f64, phase: f64) -> PeriodicFunction {
 /// | phase | *periods* | The phase shift of the function. Value of 1 means full shift around.
 #[macro_export]
 macro_rules! square {
-    (frequency = $frequency:expr) => {
+    (frequency: $frequency:expr) => {
         square!($frequency)
     };
-    (frequency = $frequency:expr, amplitude = $amplitude:expr) => {
+    (frequency: $frequency:expr, amplitude: $amplitude:expr) => {
         square!($frequency, $amplitude)
     };
-    (frequency = $frequency:expr, amplitude = $amplitude:expr, phase = $phase:expr) => {
+    (frequency: $frequency:expr, amplitude: $amplitude:expr, phase: $phase:expr) => {
         square!($frequency, $amplitude, 0.0)
     };
     ($frequency:expr) => {


### PR DESCRIPTION
This PR changes macro annotations rom from `frequency = n` to `frequency: n`. The reason for this change is to have more readable, less cumbersome annotated form of the macro.

This is, of course, a breaking change from v0.1