### PR TITLE
Remove build test lint from publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,47 +8,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-jobs:
-  build:
-
-    runs-on: ubuntu-latest
-    
-    env:
-      RUSTFLAGS: "--deny warnings"
-
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-      
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt, clippy
-    - name: Check code formatting
-      run: cargo fmt -- --check
-    - name: Run Clippy
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-features
-        
+jobs:        
   publish:
     runs-on: ubuntu-latest
-    needs: [build, lint]
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
No need to run those tests, since bors takes care of master being always "green".