### PR TITLE
Add Sync and Send constraints on PeriodicFunction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavegen"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Michal Borejszo <michael.borejszo@gmail.com>"]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,4 +85,4 @@ use alloc::boxed::Box;
 pub use waveform::Waveform;
 
 /// Type alias defining a periodic function (f64 -> f64 map)
-pub type PeriodicFunction = Box<dyn Fn(f64) -> f64>;
+pub type PeriodicFunction = Box<dyn Fn(f64) -> f64 + Send + Sync>;


### PR DESCRIPTION
Allows for the Waveform structs to be sent over threads.